### PR TITLE
Add installation instructions from the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ $ rustup toolchain install nightly
 $ cargo +nightly install --locked xray-tui
 ```
 
+### From the [AUR](https://aur.archlinux.org/packages/xray-oci-git)
+
+```bash
+paru -Sy xray-oci-git
+```
+
 ## Motivation
 
 Everyone who had to work with container images before knows about the [dive](https://github.com/wagoodman/dive) tool. It's a great tool, but it doesn't work that well for bigger images, especially the ones that are 5 GB or more in size.


### PR DESCRIPTION
Thank you for this very neat tool!

I have some issues with `dive` and while `xray` doesn't have as many features, it seems to have no bugs either ;)

I went ahead and contributed some package to the Arch User Repository, which I'll update whenever you create a new release here.
I don't have much in the way of experience with Rust yet, but I'd love to maybe help out also in the future, this is already feeling really quite good.

Ref: https://aur.archlinux.org/packages/xray-oci-git
Ref: ssh://aur@aur.archlinux.org/xray-oci-git.git
Ref: https://github.com/ccjmne/aur-xray-oci-git (clone)