### PR TITLE
Respect `$XDG_CONFIG_HOME` if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Options:
   -p, --config-path <CONFIG_PATH>
           Override the config directory location.
 
-          Default: $HOME/.xray
+          Default: $XDG_CONFIG_HOME/xray or $HOME/.config/xray
 
   -d, --docker
           Force image resolution using Docker
@@ -135,9 +135,11 @@ xray <IMAGE>[:tag]
 
 All keybindings mentioned above are **fully customizable**.
 
-When run for the first time, `xray` creates a file named `$CONFIG_DIR/keybindings.toml`, which contains all default keybindings and their description.
+When run for the first time, `xray` creates a file named `$CONFIG_DIR/keybinds.toml`, which contains all default keybindings and their description.
 
-> 💡Default `$CONFIG_DIR` is `$HOME/.xray`.
+> 💡Default `$CONFIG_DIR` is `$XDG_CONFIG_HOME/xray` or `$HOME/.config/xray`.
+
+Runtime state such as `xray.log` is stored in `$XDG_STATE_HOME/xray` or `$HOME/.local/state/xray`.
 
 You can then update the default keybindings to your liking -- `xray` will start using your new bindings automatically after a restart!
 

--- a/crates/xray/src/config.rs
+++ b/crates/xray/src/config.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::Parser;
-use dirs::home_dir;
+use dirs::{config_dir, state_dir};
 
 #[derive(clap::Args)]
 #[group(required = false, multiple = false)]
@@ -37,7 +37,7 @@ impl ClapImageSource {
 struct Arg {
     /// Override the config directory location.
     ///
-    /// Default: $HOME/.xray
+    /// Default: $XDG_CONFIG_HOME/xray or $HOME/.config/xray
     #[arg(short = 'p', long)]
     config_path: Option<PathBuf>,
     // TODO: implement layer caching
@@ -65,6 +65,7 @@ pub enum ImageSource {
 #[derive(Debug)]
 pub struct Config {
     config_path: PathBuf,
+    state_path: PathBuf,
     image: String,
     image_source: ImageSource,
 }
@@ -79,18 +80,20 @@ impl Config {
         let image_source = image_source.into_enum();
 
         let config_path = config_path
-            .or_else(|| {
-                let mut home = home_dir()?;
-                home.push(".xray");
-                Some(home)
-            })
+            .or_else(default_config_path)
             .context("failed to get the config directory")?;
+        let state_path = default_state_path()
+            .or_else(|| Some(config_path.clone()))
+            .context("failed to get the state directory")?;
 
         std::fs::create_dir_all(&config_path)
             .context("failed to create the config directory")?;
+        std::fs::create_dir_all(&state_path)
+            .context("failed to create the state directory")?;
 
         Ok(Config {
             config_path,
+            state_path,
             image,
             image_source,
         })
@@ -106,6 +109,10 @@ impl Config {
         &self.config_path
     }
 
+    pub fn state_path(&self) -> &Path {
+        &self.state_path
+    }
+
     pub fn image(&self) -> &str {
         &self.image
     }
@@ -113,4 +120,18 @@ impl Config {
     pub fn image_source(&self) -> ImageSource {
         self.image_source
     }
+}
+
+fn default_config_path() -> Option<PathBuf> {
+    config_dir().map(|mut path| {
+        path.push("xray");
+        path
+    })
+}
+
+fn default_state_path() -> Option<PathBuf> {
+    state_dir().map(|mut path| {
+        path.push("xray");
+        path
+    })
 }

--- a/crates/xray/src/main.rs
+++ b/crates/xray/src/main.rs
@@ -9,7 +9,7 @@ use xray_tui::{
 fn main() -> anyhow::Result<()> {
     let config = Config::new()?;
 
-    init_logging(Path::new(config.config_path()))?;
+    init_logging(Path::new(config.state_path()))?;
     init_keybindings(Path::new(config.config_path()))?;
 
     let image = resolve_image_from_config(&config)


### PR DESCRIPTION
In accordance with the XDG Base Directory Specification [1], favour looking into the user's preferred location for such files, if specified:

    $XDG_CONFIG_HOME/xray/keybinds.toml <<< if defined
    $XDG_STATE_HOME/xray/xray.log       <<<

    ~/.config/xray/keybinds.toml        <<< fallback otherwise
    ~/.local/state/xray/xray.log        <<<

[1]: https://specifications.freedesktop.org/basedir/latest/

---

This code base is a bliss to work with :)