### PR TITLE
Reinvent colour scheme UI using only semantic ANSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - ⛓️ Supports **size-based filtering**.
 - 🚀 Fast startup times due to optimized image parsing.
 - 🏡 Convenient and minimalistic UI.
+- 🎨 ANSI theme-aware colors that follow your terminal palette.
 - 📦 Works with **any OCI-compliant container image**.
 - ⚙️ No needless re-rendering of the UI: `xray` values your CPU cycles.
 

--- a/crates/xray/src/tui/view/command_bar.rs
+++ b/crates/xray/src/tui/view/command_bar.rs
@@ -22,6 +22,6 @@ impl CommandBar {
             KeyAction::ToggleHelp.key_bindings_display()
         ))
         .centered()
-        .gray())
+        .dim())
     }
 }

--- a/crates/xray/src/tui/view/help_popup.rs
+++ b/crates/xray/src/tui/view/help_popup.rs
@@ -7,46 +7,14 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, BorderType, Paragraph, Widget, Wrap};
 
 use super::ActivePane;
-use super::pane::{
-    FIELD_KEY_STYLE, FIELD_VALUE_STYLE, LayerInspectorNodeStyles,
-};
+use super::pane::{FIELD_KEY_STYLE, FIELD_VALUE_STYLE};
 use crate::keybindings::KeyAction;
 use crate::tui::store::AppState;
 
-const COLOR_GUIDE: &[(&[Color], &str)] = &[
-    (
-        &[
-            LayerInspectorNodeStyles::get_added_node_style(true)
-                .fg
-                .expect("should be present"),
-            LayerInspectorNodeStyles::get_added_node_style(false)
-                .fg
-                .expect("should be present"),
-        ],
-        "Added in the current layer",
-    ),
-    (
-        &[
-            LayerInspectorNodeStyles::get_modified_node_style(true)
-                .fg
-                .expect("should be present"),
-            LayerInspectorNodeStyles::get_modified_node_style(false)
-                .fg
-                .expect("should be present"),
-        ],
-        "Modified in the current layer",
-    ),
-    (
-        &[
-            LayerInspectorNodeStyles::get_deleted_node_style(true)
-                .fg
-                .expect("should be present"),
-            LayerInspectorNodeStyles::get_deleted_node_style(false)
-                .fg
-                .expect("should be present"),
-        ],
-        "Deleted in the current layer",
-    ),
+const COLOR_GUIDE: &[(Color, &str)] = &[
+    (Color::Green, "Added in the current layer"),
+    (Color::Yellow, "Modified in the current layer"),
+    (Color::Red, "Deleted in the current layer"),
 ];
 
 /// A simple help popup that displays all hotkeys and other useful information.
@@ -178,7 +146,7 @@ fn format_hotkeys_section(
             Span::styled(
                 format!("{hotkey:>longest_hotkey$}  "),
                 // Make the hotkeys easier to see among the text
-                FIELD_KEY_STYLE.fg(Color::LightBlue),
+                FIELD_KEY_STYLE.fg(Color::Cyan),
             ),
             Span::styled(description, FIELD_VALUE_STYLE),
         ])
@@ -196,13 +164,8 @@ fn format_color_guide_section() -> impl Iterator<Item = Line<'static>> {
     )
     .into_iter()
     .chain(chainable_blank_line())
-    .chain(COLOR_GUIDE.iter().map(|&(colors, description)| {
-        let mut colors = colors
-            .iter()
-            .map(|&color| Span::styled("   ", Style::new().bg(color)))
-            .intersperse(Span::styled(" or ", FIELD_VALUE_STYLE))
-            .collect::<Vec<_>>();
-
+    .chain(COLOR_GUIDE.iter().map(|&(color, description)| {
+        let mut colors = vec![Span::styled("   ", Style::new().bg(color))];
         // Separator between colors and their meaning
         colors.push(Span::styled("  ", FIELD_VALUE_STYLE));
         // Actual description

--- a/crates/xray/src/tui/view/pane.rs
+++ b/crates/xray/src/tui/view/pane.rs
@@ -16,11 +16,11 @@ pub use layer_info::LayerInfoPane;
 pub use layer_inspector::LayerInspectorPane;
 pub use layer_selector::LayerSelectorPane;
 use ratatui::layout::Rect;
-use ratatui::style::{Style, Stylize};
+use ratatui::style::{Modifier, Style, Stylize};
 use ratatui::text::{Line, Text};
 use ratatui::widgets::block::Title;
 use ratatui::widgets::{Block, BorderType, Paragraph, Widget, Wrap};
-use style::{ACTIVE_FIELD_STYLE, text_color};
+use style::{ACTIVE_FIELD_STYLE, text_style};
 pub(super) use style::{
     FIELD_KEY_STYLE, FIELD_VALUE_STYLE, LayerInspectorNodeStyles,
 };
@@ -59,16 +59,10 @@ impl Pane {
         let pane_is_active =
             state.active_pane == self.into() && !state.show_help_popup;
 
-        let text_color = text_color(pane_is_active);
-        // Don't override the field key's fg color unless the pane is not active.
-        let field_key_style = if pane_is_active && FIELD_KEY_STYLE.fg.is_some()
-        {
-            FIELD_KEY_STYLE
-        } else {
-            FIELD_KEY_STYLE.fg(text_color)
-        };
-        let field_value_style = FIELD_VALUE_STYLE.fg(text_color);
-        let active_field_style = ACTIVE_FIELD_STYLE.fg(text_color);
+        let pane_text_style = text_style(pane_is_active);
+        let field_key_style = FIELD_KEY_STYLE.patch(pane_text_style);
+        let field_value_style = FIELD_VALUE_STYLE.patch(pane_text_style);
+        let active_field_style = ACTIVE_FIELD_STYLE.patch(pane_text_style);
 
         // Two rows are taken by the block borders
         let remaining_rows = pane_rows - 2;
@@ -371,9 +365,9 @@ impl Pane {
     /// Returns a styled [Block] for the pane.
     fn get_styled_block(&self, is_active: bool) -> Block<'_> {
         let (border_type, border_style) = if is_active {
-            (BorderType::Thick, Style::new().white())
+            (BorderType::Thick, Style::new().add_modifier(Modifier::BOLD))
         } else {
-            (BorderType::Plain, Style::new().gray())
+            (BorderType::Plain, Style::new().add_modifier(Modifier::DIM))
         };
 
         Block::bordered()
@@ -395,9 +389,9 @@ impl Pane {
         };
 
         let title = if is_active {
-            title.bold().white()
+            title.bold()
         } else {
-            title.not_bold().gray()
+            title.not_bold().dim()
         };
 
         title.into_centered_line()

--- a/crates/xray/src/tui/view/pane/filter_popup.rs
+++ b/crates/xray/src/tui/view/pane/filter_popup.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::path::Path;
 
 use ratatui::layout::Constraint;
-use ratatui::style::{Color, Style, Stylize};
+use ratatui::style::{Modifier, Style, Stylize};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, BorderType, Padding, Paragraph, Wrap};
 use regex::Regex;
@@ -174,22 +174,17 @@ impl FilterPopup {
             |seq: &'static str, description: &'static str| {
                 if keybindings.len() > 1 {
                     // Separate keybindings
-                    keybindings
-                        .push(Span::styled(", ", Style::new().fg(Color::Gray)));
+                    keybindings.push(Span::styled(", ", Style::new().add_modifier(Modifier::DIM)));
                 }
 
                 // Add the key sequence
-                keybindings.push(Span::styled(
-                    seq,
-                    Style::new().bold().fg(Color::White),
-                ));
+                keybindings.push(Span::styled(seq, Style::new().bold()));
                 // Separator
-                keybindings
-                    .push(Span::styled(" - ", Style::new().fg(Color::Gray)));
+                keybindings.push(Span::styled(" - ", Style::new().add_modifier(Modifier::DIM)));
                 // Add the description
                 keybindings.push(Span::styled(
                     description,
-                    Style::new().fg(Color::Gray),
+                    Style::new().add_modifier(Modifier::DIM),
                 ));
             };
 

--- a/crates/xray/src/tui/view/pane/style.rs
+++ b/crates/xray/src/tui/view/pane/style.rs
@@ -17,27 +17,25 @@ pub struct LayerInspectorNodeStyles;
 impl LayerInspectorNodeStyles {
     /// A style for a node that is currently selected.
     const SELECTED_NODE_STYLE: Style =
-        Style::new().fg(Color::Black).bg(Color::White);
+        Style::new().add_modifier(Modifier::REVERSED);
 
     /// A style for a node that was added in the current layer and is inside the active pane.
-    const ACTIVE_PANE_ADDED_NODE_STYLE: Style =
-        Style::new().fg(Color::Indexed(106));
+    const ACTIVE_PANE_ADDED_NODE_STYLE: Style = Style::new().fg(Color::Green);
     /// A style for a node that was modified in the current layer and is inside the active pane.
     const ACTIVE_PANE_MODIFIED_NODE_STYLE: Style =
-        Style::new().fg(Color::Indexed(220));
+        Style::new().fg(Color::Yellow);
     /// A style for a node that was deleted in the current layer and is inside the active pane.
-    const ACTIVE_PANE_DELETED_NODE_STYLE: Style =
-        Style::new().fg(Color::Indexed(160));
+    const ACTIVE_PANE_DELETED_NODE_STYLE: Style = Style::new().fg(Color::Red);
 
     /// A style for a node that was added in the current layer and is inside the inactive pane.
     const INACTIVE_PANE_ADDED_NODE_STYLE: Style =
-        Style::new().fg(Color::Indexed(108));
+        Style::new().fg(Color::Green).add_modifier(Modifier::DIM);
     /// A style for a node that was modified in the current layer and is inside the inactive pane.
     const INACTIVE_PANE_MODIFIED_NODE_STYLE: Style =
-        Style::new().fg(Color::Indexed(222));
+        Style::new().fg(Color::Yellow).add_modifier(Modifier::DIM);
     /// A style for a node that was deleted in the current layer and is inside the inactive pane.
     const INACTIVE_PANE_DELETED_NODE_STYLE: Style =
-        Style::new().fg(Color::Indexed(124));
+        Style::new().fg(Color::Red).add_modifier(Modifier::DIM);
 
     pub const fn get_selected_node_style() -> Style {
         Self::SELECTED_NODE_STYLE
@@ -65,12 +63,12 @@ impl LayerInspectorNodeStyles {
     }
 }
 
-/// Returns the text [Color] based on whether the [Pane](super::Pane) is active.
-pub fn text_color(pane_is_active: bool) -> Color {
+/// Returns the base text [Style] based on whether the [Pane](super::Pane) is active.
+pub fn text_style(pane_is_active: bool) -> Style {
     if pane_is_active {
-        Color::White
+        Style::new()
     } else {
-        Color::Gray
+        Style::new().add_modifier(Modifier::DIM)
     }
 }
 
@@ -83,8 +81,8 @@ pub fn layer_status_indicator_style(
 ) -> Style {
     let style = Style::default();
     match layer_idx.cmp(selected_layer_idx) {
-        Ordering::Equal => style.bg(Color::LightGreen),
-        Ordering::Less => style.bg(Color::LightMagenta),
+        Ordering::Equal => style.bg(Color::Green),
+        Ordering::Less => style.bg(Color::Magenta),
         Ordering::Greater => style,
     }
 }


### PR DESCRIPTION
This presents notably three benefits:

1. the code is somewhat more comprehensible
2. the application gets automatically themed according to the user's terminal colour-scheme
3. we supposed dark- and light-mode switching automatically

---

Alright, that one's a little bit ambitious. But it turns out that *so little* was needed in order to effect that change, I could get it done and review fairly fast.
I don't mean to be spamming you with heaps of nonsense, and this one in particular you may have mixed feelings about, but I'm happy to arrive at a solution together!

Or even leave it as it is; it's fine enough that way :)
I'm already thankful for the tool being *functional*!

Still, we have this basis now, if we want to go run with it. I won't be offended it it doesn't make it to the main branch.
Cheers!